### PR TITLE
Disable Atlantis autoplan

### DIFF
--- a/atlantis.yml
+++ b/atlantis.yml
@@ -1,0 +1,5 @@
+version: 3
+projects:
+  - dir: .
+    autoplan:
+      enabled: false


### PR DESCRIPTION
To disable messages from Atlantis, such as
```
Atlantis commands can't be run on fork pull requests. To enable, set --allow-fork-prs
```
https://github.com/duolingo/pre-commit-hooks/pull/1#issuecomment-541732190