### PR TITLE
Add "max_" to line length name for python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,5 @@ combine_as_imports=true
 force_grid_wrap=0
 include_trailing_comma=true
 indent_size=4
-line_length=100
+max_line_length=100
 multi_line_output=3


### PR DESCRIPTION
Inconsistent with the other formats; I believe a "max" is missing.

Pycharm also complains that `combine_as_imports`, `force_grid_wrap`, and `include_trailing_comma` are not valid keys, although I'm sure they were added for a reason so I'll leave them as-is.