### PR TITLE
Add support for Typescript 3.8 files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: .
-    rev: 1.2.0
+    rev: 1.3.0
     hooks:
       - id: duolingo
   - repo: local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 
 # Alpine base packages
 RUN apk update && apk upgrade && apk add --no-cache \
@@ -6,7 +6,8 @@ RUN apk update && apk upgrade && apk add --no-cache \
   git \
   nodejs-npm \
   openjdk8 \
-  python3
+  python3 \
+  py3-pip
 
 # Alpine tool packages
 RUN apk update && apk upgrade && apk add --no-cache \
@@ -37,7 +38,7 @@ RUN coursier bootstrap org.scalameta:scalafmt-cli_2.12:2.6.4 \
 # NPM packages
 # https://github.com/npm/npm/issues/20861#issuecomment-400786321
 RUN npm config set unsafe-perm true && npm install -g \
-    prettier@1.19.1 \
+    prettier@2.1.1 \
     svgo@1.3.0 \
     typescript@3.6.3 \
   && npm install \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo currently contains a single [pre-commit](https://pre-commit.com/) hook that internally runs several code formatters in parallel.
 
-- [Prettier](https://github.com/prettier/prettier) v1.19.1 for HTML, JS, JSX, Markdown, TypeScript, YAML
+- [Prettier](https://github.com/prettier/prettier) v2.1.1 for HTML, JS, JSX, Markdown, TypeScript, YAML
 - [Black](https://github.com/psf/black) v19.3b0 for Python
 - [google-java-format](https://github.com/google/google-java-format) v1.7 for Java
 - [ktlint](https://github.com/pinterest/ktlint) v0.34.2 for Kotlin
@@ -20,7 +20,7 @@ Repo maintainers can declare this hook in `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/duolingo/pre-commit-hooks.git
-  rev: 1.2.0
+  rev: 1.3.0
   hooks:
     - id: duolingo
       args: [--python-version=2] # Optional, defaults to Python 3


### PR DESCRIPTION
 - Updates Prettier to 2.1.1
 - Updates Alpine to 3.12
  - Necessary as Alpine 3.8 packaged NodeJs 8 and Prettier 2 relies
  on syntax that is only supported on NodeJs versions > 10.