### PR TITLE
Update to ktfmt 0.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install --upgrade pip && pip3 install \
 
 # Standalone binaries
 RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar
-RUN wget https://search.maven.org/remotecontent?filepath=com/facebook/ktfmt/0.22/ktfmt-0.22-jar-with-dependencies.jar
+RUN wget https://search.maven.org/remotecontent?filepath=com/facebook/ktfmt/0.25/ktfmt-0.25-jar-with-dependencies.jar
 RUN wget https://github.com/mvdan/sh/releases/download/v3.2.0/shfmt_v3.2.0_linux_amd64 -O shfmt \
   && chmod +x shfmt
 RUN wget https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -O tf.zip \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo currently contains a single [pre-commit](https://pre-commit.com/) hook
 - [Black](https://github.com/psf/black) v20.8b1 for Python
 - [autoflake](https://github.com/myint/autoflake) v1.4 for Python
 - [google-java-format](https://github.com/google/google-java-format) v1.9 for Java
-- [ktfmt](https://github.com/facebookincubator/ktfmt) v0.22 for Kotlin
+- [ktfmt](https://github.com/facebookincubator/ktfmt) v0.25 for Kotlin
 - [scalafmt](https://scalameta.org/scalafmt/) v2.7.5 for Scala
 - [shfmt](https://github.com/mvdan/sh) v3.2.0 for Shell
 - [terraform fmt](https://github.com/hashicorp/terraform) v0.11.14 and v0.12.29 for Terraform

--- a/entry.ts
+++ b/entry.ts
@@ -192,7 +192,7 @@ const HOOKS: Record<HookName, LockableHook> = {
         // at 256m works and only increases my laptop's time to format a test repo from 64s to 72s
         "-Xmx256m",
         "-jar",
-        "/ktfmt-0.22-jar-with-dependencies.jar",
+        "/ktfmt-0.25-jar-with-dependencies.jar",
         "--google-style",
         ...sources,
       ),


### PR DESCRIPTION
## Description

This bumps ktfmt to 0.25, allowing it to properly handle [Kotlin 1.5's value classes](https://kotlinlang.org/docs/whatsnew15.html#inline-classes). See https://github.com/facebookincubator/ktfmt/issues/236 for more details.

## Verification steps

In the Android repo, I formatted

```
@JvmInline 
value class Color(@ColorInt val colorInt: Int)
```

which resulted in the expected

```
@JvmInline value class Color(@ColorInt val colorInt: Int)
```

as opposed to the prior

```
@JvmInline value 

class Color(@ColorInt val colorInt: Int)
```

seen with ktfmt 0.22
