### PR TITLE
Run ktfmt on .kts files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ indent_style=space
 insert_final_newline=true
 trim_trailing_whitespace=true
 
-[*.{gradle,java,kt,sh,xml,yaml,yml}]
+[*.{gradle,java,kt,kts,sh,xml,yaml,yml}]
 indent_size=2
 max_line_length=100
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache --virtual .build-deps \
     typescript@4.3.5 \
   && apk del .build-deps \
   && wget https://github.com/google/google-java-format/releases/download/v1.11.0/google-java-format-1.11.0-all-deps.jar -O google-java-format \
-  && wget https://search.maven.org/remotecontent?filepath=com/facebook/ktfmt/0.27/ktfmt-0.27-jar-with-dependencies.jar -O ktfmt \
+  && wget https://search.maven.org/remotecontent?filepath=com/facebook/ktfmt/0.28/ktfmt-0.28-jar-with-dependencies.jar -O ktfmt \
   && wget https://github.com/mvdan/sh/releases/download/v3.3.1/shfmt_v3.3.1_linux_amd64 -O shfmt \
   && chmod +x shfmt \
   && wget https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -O tf.zip \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo currently contains a single [pre-commit](https://pre-commit.com/) hook
 - [autoflake](https://github.com/myint/autoflake) v1.4 for Python
 - [isort](https://github.com/PyCQA/isort) v5.9.3 for Python
 - [google-java-format](https://github.com/google/google-java-format) v1.11.0 for Java
-- [ktfmt](https://github.com/facebookincubator/ktfmt) v0.27 for Kotlin
+- [ktfmt](https://github.com/facebookincubator/ktfmt) v0.28 for Kotlin
 - [scalafmt](https://scalameta.org/scalafmt/) v2.7.5 for Scala
 - [shfmt](https://github.com/mvdan/sh) v3.3.1 for Shell
 - [terraform fmt](https://github.com/hashicorp/terraform) v0.11.14 and v0.12.29 for Terraform

--- a/entry.ts
+++ b/entry.ts
@@ -196,7 +196,7 @@ const HOOKS: Record<HookName, LockableHook> = {
         "--google-style",
         ...sources,
       ),
-    include: /\.kt$/,
+    include: /\.kts?$/,
     runAfter: [HookName.Sed],
   }),
   [HookName.PrettierJs]: createLockableHook({


### PR DESCRIPTION
`.kts` files are [kotlin run scripts](https://kotlinlang.org/docs/command-line.html#run-scripts), and Google is encouraging migrating Android [Gradle build scripts from Groovy to KTS](https://developer.android.com/studio/build/migrate-to-kts).

[ktfmt 0.28](https://github.com/facebookincubator/ktfmt/releases/tag/v0.28) fixed an issue where it wasn't processing `.kts` files, so we also need to bump that version.