### PR TITLE
Build for arm, bump to 1.5.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: .
-    rev: 1.5.2
+    rev: 1.5.3
     hooks:
       - id: duolingo
   - repo: local

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: duolingo
   name: Duolingo
-  entry: duolingo/pre-commit-hooks:1.5.2 /entry
+  entry: duolingo/pre-commit-hooks:1.5.3 /entry
   language: docker_image
   types: [text]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Repo maintainers can declare this hook in `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/duolingo/pre-commit-hooks.git
-  rev: 1.5.2
+  rev: 1.5.3
   hooks:
     - id: duolingo
       args: [--python-version=2] # Optional, defaults to Python 3


### PR DESCRIPTION
Bumps version to 1.5.3, built via:
```
docker buildx build --platform linux/amd64,linux/arm64 -t duolingo/pre-commit-hooks:latest -t duolingo/pre-commit-hooks:1.5.3 .
```