### PR TITLE
Add editor config for Makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,9 @@ indent_style=space
 insert_final_newline=true
 trim_trailing_whitespace=true
 
+[makefile]
+indent_style=tab
+
 [*.{gradle,java,kt,kts,sh,xml,yaml,yml}]
 indent_size=2
 max_line_length=100


### PR DESCRIPTION
Add editor config for Makefiles to prevent spaces being used instead of tabs.