### PR TITLE
Introduce a Jenkins pipeline linter (TEST-2256)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN apk add --no-cache --virtual .build-deps \
     -r sonatype:snapshots --main org.scalafmt.cli.Cli \
     --standalone \
     -o scalafmt \
-  && rm /bin/coursier
+  && rm /bin/coursier \
+  && apk add curl
 
 # Local files
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,5 @@ test:
 			&& cp -r /test/after expected \
 			&& /entry actual/* \
 			&& diff -r expected actual \
+			&& sh /test/check_linters.sh \
 			&& echo "All tests passed!"'

--- a/entry.ts
+++ b/entry.ts
@@ -201,7 +201,9 @@ const HOOKS: Record<HookName, LockableHook> = {
         `${JENKINS_URL}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)`,
       );
 
-      // Request failed. Can either auto-succeed or auto-fail. I vote auto-fail. @Reviewer?
+      // Request failed. Can either auto-succeed or auto-fail. Auto-fail seems natural to
+      // me because in some sense the check failed, but in this case perhaps it's better
+      // to just let people push and they'll discover the errors when they run. @Reviewer?
       if (!JENKINS_CRUMB.startsWith("Jenkins")) {
         console.error("not sure what to do here yet");
       } else {

--- a/test/check_linters.sh
+++ b/test/check_linters.sh
@@ -1,6 +1,6 @@
 # Testing script only to be called inside the container built by
 # `make test`. Ensures that linting succeeds on all well-formed
-# test files and fails on all mal-formed ones
+# test files and fails on all malformed ones
 
 failed=0
 
@@ -12,7 +12,7 @@ done
 
 for file in "/test/lint_tests/should_fail/*"
 do
-    ! /entry $file
+    ! /entry $file 2> /dev/null
     failed=$((failed || $?))
 done
 

--- a/test/check_linters.sh
+++ b/test/check_linters.sh
@@ -1,0 +1,19 @@
+# Testing script only to be called inside the container built by
+# `make test`. Ensures that linting succeeds on all well-formed
+# test files and fails on all mal-formed ones
+
+failed=0
+
+for file in "/test/lint_tests/should_succeed/*"
+do
+    /entry $file
+    failed=$((failed || $?))
+done
+
+for file in "/test/lint_tests/should_fail/*"
+do
+    ! /entry $file
+    failed=$((failed || $?))
+done
+
+exit $failed

--- a/test/lint_tests/should_fail/no_agent.jenkinsfile
+++ b/test/lint_tests/should_fail/no_agent.jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+  agent
+  stages {
+    stage ('Initialize') {
+      steps {
+        echo 'Placeholder.'
+      }
+    }
+  }
+}

--- a/test/lint_tests/should_fail/no_stages.jenkinsfile
+++ b/test/lint_tests/should_fail/no_stages.jenkinsfile
@@ -1,0 +1,3 @@
+pipeline {
+  agent any
+}

--- a/test/lint_tests/should_succeed/basic_pipeline.jenkinsfile
+++ b/test/lint_tests/should_succeed/basic_pipeline.jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+  agent any
+  stages {
+    stage ('Initialize') {
+      steps {
+        echo 'Placeholder.'
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new precommit hook to validate Jenkins pipelines before pushing and discovering they don't work.

Validation:
- [ ] Decide if this is worth doing/having.
- [ ] Inspect the tests.
- [ ] Run this on a malformed pipeline and inspect the output format (see screenshot below for what I have--note that this output comes from before I redirected the errors to dev null for the test script).

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/25823209/192299261-5e914f5c-d9c3-469d-bcf7-d7ee2b350e4a.png">
