### PR TITLE
Update Prettier to 2.8.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: .
-    rev: 1.6.1
+    rev: 1.6.2
     hooks:
       - id: duolingo
         exclude: test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ RUN apk add --no-cache --virtual .build-deps \
   && echo 'source /black21-venv/bin/activate && black "$@"' > /usr/bin/black21 \
   && chmod +x /usr/bin/black21 \
   && npm install -g \
-    @prettier/plugin-xml@2.0.1 \
-    @types/node@17.0.23 \
-    prettier@2.6.2 \
+    @prettier/plugin-xml@2.2.0 \
+    @types/node@18.16.0 \
+    prettier@2.8.8 \
     svgo@2.8.0 \
-    typescript@4.6.3 \
+    typescript@5.0.4 \
   && apk del .build-deps \
   && wget https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar -O google-java-format \
   && wget https://search.maven.org/remotecontent?filepath=com/facebook/ktfmt/0.35/ktfmt-0.35-jar-with-dependencies.jar -O ktfmt \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo currently contains a single [pre-commit](https://pre-commit.com/) hook that internally runs several code formatters in parallel.
 
-- [Prettier](https://github.com/prettier/prettier) v2.6.2 for CSS, HTML, JS, JSX, Markdown, Sass, TypeScript, XML, YAML
+- [Prettier](https://github.com/prettier/prettier) v2.8.8 for CSS, HTML, JS, JSX, Markdown, Sass, TypeScript, XML, YAML
 - [Black](https://github.com/psf/black) v22.3.0 for Python 3, v21.12b0 for Python 2
 - [autoflake](https://github.com/myint/autoflake) v1.4 for Python
 - [isort](https://github.com/PyCQA/isort) v5.10.1 for Python
@@ -28,7 +28,7 @@ Repo maintainers can declare this hook in `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/duolingo/pre-commit-hooks.git
-  rev: 1.6.1
+  rev: 1.6.2
   hooks:
     - id: duolingo
       args: # Optional


### PR DESCRIPTION
Preparing to (attempt to) upgrade duolingo-web to TypeScript 5.0.4. If there is a specific reason to stay at node@17 lmk