### PR TITLE
Update isort to 5.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache --virtual .build-deps \
     python3 \
   && pip3 install \
     autoflake==1.7.8 \
-    isort==5.12.0 \
+    isort==5.13.2 \
     ruff==0.1.5 \
   && python3 -m venv /black21-venv \
   && source /black21-venv/bin/activate \


### PR DESCRIPTION
To recognize `tomllib` as a python builtin from 3.11 (see: https://github.com/duolingo/infra-pollybot/pull/29/files#r1765746658)