### PR TITLE
Allow kotlin empty collections that don't allocate

### DIFF
--- a/entry.ts
+++ b/entry.ts
@@ -316,11 +316,7 @@ const HOOKS: Record<HookName, LockableHook> = {
               // is similarly implemented as a singleton
               data = data
                 .replace(/\barrayOf\(\)/g, "emptyArray()")
-                .replace(/\blistOf\(\)/g, "emptyList()")
-                .replace(/\bmapOf\(\)/g, "emptyMap()")
-                .replace(/\bsequenceOf\(\)/g, "emptySequence()")
-                .replace(/\bsetOf\(\)/g, "emptySet()");
-
+                .replace(/\bsequenceOf\(\)/g, "emptySequence()");
               // Remove unnecessary constructor keyword
               data = data.replace(/(?<=\bclass \S+) constructor(?=\()/g, "");
             }


### PR DESCRIPTION
These are already implemented using singletons and idiomatically `listOf` etc are interchangeable with `emptyList`

- `listOf` directly calls `emptyList`
- `mapOf` directly calls `emptyMap`
- `setOf` directly calls `emptySet`

`sequenceOf` does return `emptySequence` from the no param call, but I'm not sure if it creates some array for the `varargs`.

I'm not familiar with `arrayOf`