### PR TITLE
Preserve C++ include order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+
+# Sorting includes is dangerous and can break compilation
+SortIncludes: Never

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!.clang-format
 !.editorconfig
 !entry.ts
 !ruff.toml

--- a/entry.ts
+++ b/entry.ts
@@ -178,7 +178,7 @@ const HOOKS: Record<HookName, LockableHook> = {
       run(
         "/clang-format",
         "-i", // Edit files in-place
-        "--style=Google",
+        "--style=file:/.clang-format",
         ...sources,
       ),
     include: /\.(cpp|proto$)/,

--- a/test/after/hello.cpp
+++ b/test/after/hello.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cmath>
 
 int main() {
   std::cout << "Hello world";

--- a/test/before/hello.cpp
+++ b/test/before/hello.cpp
@@ -1,3 +1,4 @@
  #include  <iostream>
+ #include   <cmath>
 
  int  main ( ){std::cout<<"Hello world";return 0 ;}


### PR DESCRIPTION
Reported by @swnydick 

Normally I'd be inclined to recommend using [ignore comments](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code), but this problem is somewhat more serious in C++ than in other languages where order is mostly cosmetic