### PR TITLE
Update Java to patched 21.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ RUN tsc \
 # eclipse-temurin:21-alpine java --list-modules`, then removing modules by trial
 # and error until `make test` throws ClassNotFoundException. When first
 # implemented, this custom JRE reduced our image size from 574 MB to 469 MB
-FROM eclipse-temurin:21-alpine as jre
-RUN jlink \
+FROM amazoncorretto:21.0.6-alpine3.21 as jre
+RUN apk add binutils && jlink \
   --add-modules java.se,jdk.compiler,jdk.unsupported \
-  --compress 2 \
+  --compress zip-6 \
   --no-header-files \
   --no-man-pages \
   --output /jre \


### PR DESCRIPTION
Fixes Java bug that happens on Docker + macOS 15.2 + M4

https://github.com/corretto/corretto-21/issues/85
https://bugs.openjdk.org/browse/JDK-8345296