### PR TITLE
Have Apiary clients sorted as third party by ruff (LIB-93)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,9 @@ convention = "pep257"
 
 [isort]
 combine-as-imports = true
+# We force Apairy generated clients to be sorted as external libraries to prevent
+# thrashing between local and CI environments.
+known-third-party = ["*_backend_client"]
 
 [lint]
 ignore = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,7 +8,7 @@ convention = "pep257"
 
 [isort]
 combine-as-imports = true
-# We force Apairy generated clients to be sorted as external libraries to prevent
+# We force Apiary generated clients to be sorted as external libraries to prevent
 # thrashing between local and CI environments.
 known-third-party = ["*_backend_client"]
 


### PR DESCRIPTION
Discussed in detail internally. Short version:

- Apiary-generated clients are sorted with third-party libraries in CI because they aren't actually generated yet
- Locally, users typically have run the build process which generated Apiary clients, so they get sorted with first-party libs
- This causes pre-commit to alter the sort locally, and then CI to alter it right back.