### PR TITLE
Fix GLOBAL_EXCLUDES regex for generated skills directories

### DIFF
--- a/entry.ts
+++ b/entry.ts
@@ -484,7 +484,7 @@ const HOOKS: Record<HookName, Hook> = {
 /** Files that match this pattern should never be processed */
 const GLOBAL_EXCLUDES = (() => {
   const FOLDER_EXCLUDES = [
-    ".claude/skills/generated_*",
+    "\\.claude/skills/generated_[^/]+",
     "build",
     "node_modules",
   ];


### PR DESCRIPTION
## Summary

- The glob pattern `.claude/skills/generated_*` added in #68 was used directly in a `RegExp()` constructor, where `*` is a regex quantifier (zero or more `_`), not a glob wildcard
- This meant the exclusion never matched actual directory names like `generated_architecture_architecture-rule`, so Prettier was processing SKILL.md files
- Prettier escaped `**/*.swift` glob patterns and stripped trailing blank lines, causing test failures

## Test plan

- [ ] `make test` passes

Fixes #68 (reported in https://github.com/duolingo/pre-commit-hooks/pull/68#issuecomment-4145006669)

🤖 Generated with [Claude Code](https://claude.com/claude-code)