### PR TITLE
Add multi-architecture support to Dockerfile (SD-698)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,17 @@ RUN apk add binutils && jlink \
   --strip-debug
 
 FROM alpine:3.23.4
+ARG TARGETARCH
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PIP_NO_CACHE_DIR=1
 RUN <<EOF
 set -eu
+
+# Map Docker's TARGETARCH to download URL arch suffixes
+case "${TARGETARCH}" in
+  arm64) ARCH_GO=arm64; ARCH_UNAME=aarch64 ;;
+  *)     ARCH_GO=amd64; ARCH_UNAME=x86_64 ;;
+esac
 
 # Install Alpine dependencies
 apk add --no-cache --virtual .build-deps \
@@ -80,20 +87,25 @@ coursier bootstrap org.scalameta:scalafmt-cli_2.13:3.11.0 \
   -o scalafmt
 
 # Install static binaries
-wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_linux-amd64 -O clang-format
-chmod +x clang-format
+if [ "${ARCH_GO}" = "arm64" ]; then
+  apk add --no-cache clang20-extra-tools
+  ln -sf /usr/lib/llvm20/bin/clang-format /clang-format
+else
+  wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-796e77c/clang-format-20_linux-amd64 -O clang-format
+  chmod +x clang-format
+fi
 wget https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format-1.35.0-all-deps.jar -O google-java-format
 wget https://repo1.maven.org/maven2/com/facebook/ktfmt/0.62/ktfmt-0.62-with-dependencies.jar -O ktfmt
 wget https://repo1.maven.org/maven2/com/squareup/sort-gradle-dependencies-app/0.16/sort-gradle-dependencies-app-0.16-all.jar -O gradle-dependencies-sorter
-wget https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64 -O shfmt
+wget https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_${ARCH_GO} -O shfmt
 chmod +x shfmt
-wget https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz -O taplo.gz
+wget https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-${ARCH_UNAME}.gz -O taplo.gz
 gzip -d taplo.gz
 chmod +x taplo
-wget https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_linux_amd64.zip -O tf.zip
+wget https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_linux_${ARCH_GO}.zip -O tf.zip
 unzip tf.zip
 rm tf.zip LICENSE.txt
-wget https://releases.hashicorp.com/packer/1.15.1/packer_1.15.1_linux_amd64.zip -O packer.zip
+wget https://releases.hashicorp.com/packer/1.15.1/packer_1.15.1_linux_${ARCH_GO}.zip -O packer.zip
 unzip packer.zip
 rm packer.zip LICENSE.txt
 


### PR DESCRIPTION
Add multi-architecture support to the Dockerfile

- Use `TARGETARCH` build arg to map Docker arch names to Go (`amd64`/`arm64`) and uname (`x86_64`/`aarch64`) conventions
- Install distro-packaged `clang-format` on arm64 since no static binary is available; keep the static binary on amd64
- Parameterize download URLs for shfmt, taplo, terraform, and packer with the appropriate arch variable

## Verification Steps

- [x] Build the image for amd64 (`docker build --platform linux/amd64 .`) and confirm all tools are present
  - `docker build --platform linux/amd64 --network=host -q -t pre-commit-amd64 .`
 
```
docker run --rm --platform linux/amd64 pre-commit-amd64 sh -c '
    /clang-format --version
    /shfmt --version
    /terraform version
    /packer --version
    /taplo --version
    /gofmt -h 2>&1 | head -1
    ls -la /clang-format
  '
```


- [x] Build the image for arm64 (`docker build --platform linux/arm64 .`) and confirm `clang-format` resolves to the distro package
  - `docker build --platform linux/arm64 --network=host -q -t pre-commit-arm64 .`

```
docker run --rm --platform linux/arm64 pre-commit-arm64 sh -c '
    /clang-format --version
    /shfmt --version
    /terraform version
    /packer --version
    /taplo --version
    /gofmt -h 2>&1 | head -1
    ls -la /clang-format
  '
```

- [x] Run a sample pre-commit hook in each image to verify tools execute correctly
  - [x] tested `amd64` locally on `infra-test`
  - [x] tested `arm64` locally with `duolingo-sg`