### PR TITLE
Sort compatibly with @typescript-eslint/member-ordering

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,10 @@ import sortKeys from "eslint-plugin-sort-keys";
 import unicorn from "eslint-plugin-unicorn";
 import tseslint from "typescript-eslint";
 
+// Sort properties before methods to avoid conflicts with
+// @typescript-eslint/member-ordering, which expects that order by default
+const PERFECTIONIST_CONFIG = ["error", { groups: ["property", "method"] }];
+
 const config = {
   files: ["**/*.{js,jsx,mjs,ts,tsx}"],
   languageOptions: { parser: tseslint.parser },
@@ -137,14 +141,15 @@ const config = {
     // "jsdoc/text-escaping": "error",
 
     // perfectionist rules. https://perfectionist.dev/rules
+    "perfectionist/sort-classes": PERFECTIONIST_CONFIG,
     // "perfectionist/sort-enums" // Reordering can change numeric enum values
     // "perfectionist/sort-heritage-clauses" // Not worth the churn when interfaces are involved
     // "perfectionist/sort-imports" // TODO: Enable once grouping is more configurable
-    "perfectionist/sort-interfaces": "error",
+    "perfectionist/sort-interfaces": PERFECTIONIST_CONFIG,
     // "perfectionist/sort-intersection-types" // Not worth the churn when interfaces are involved
     "perfectionist/sort-named-exports": "error",
     "perfectionist/sort-named-imports": "error",
-    "perfectionist/sort-object-types": "error",
+    "perfectionist/sort-object-types": PERFECTIONIST_CONFIG,
     // "perfectionist/sort-objects // Prefer sort-keys because it leaves computed properties alone
     // "perfectionist/sort-switch-case" // TODO: Enable once it supports partitionByNewLine
     // "perfectionist/sort-union-types" // Not worth the churn when interfaces are involved

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,9 +7,28 @@ import sortKeys from "eslint-plugin-sort-keys";
 import unicorn from "eslint-plugin-unicorn";
 import tseslint from "typescript-eslint";
 
-// Sort properties before methods to avoid conflicts with
-// @typescript-eslint/member-ordering, which expects that order by default
-const PERFECTIONIST_CONFIG = ["error", { groups: ["property", "method"] }];
+// Match @typescript-eslint/member-ordering's default order for interfaces and
+// type literals: index signatures, then properties, then methods.
+// Perfectionist's `method` selector captures both real method signatures
+// (`foo(): void`, a TSMethodSignature) and function-typed properties (`foo: ()
+// => void`, a TSPropertySignature), but typescript-eslint and most readers
+// treat the latter as a field. We carve those out via a custom group: only
+// TSPropertySignature exposes elementValue, so `selector: method` +
+// `elementValuePattern` matches them and not real methods. The nested array
+// merges them back into `property`.
+const PERFECTIONIST_CONFIG = [
+  "error",
+  {
+    customGroups: [
+      {
+        elementValuePattern: ".",
+        groupName: "function-property",
+        selector: "method",
+      },
+    ],
+    groups: ["index-signature", ["property", "function-property"], "method"],
+  },
+];
 
 const config = {
   files: ["**/*.{js,jsx,mjs,ts,tsx}"],
@@ -141,7 +160,7 @@ const config = {
     // "jsdoc/text-escaping": "error",
 
     // perfectionist rules. https://perfectionist.dev/rules
-    "perfectionist/sort-classes": PERFECTIONIST_CONFIG,
+    // "perfectionist/sort-classes" // Not worth all the config needed to match @typescript-eslint/member-ordering perfectly
     // "perfectionist/sort-enums" // Reordering can change numeric enum values
     // "perfectionist/sort-heritage-clauses" // Not worth the churn when interfaces are involved
     // "perfectionist/sort-imports" // TODO: Enable once grouping is more configurable

--- a/test/after/hello.ts
+++ b/test/after/hello.ts
@@ -42,6 +42,12 @@ interface Options {
   verbose: boolean;
 }
 
+interface Mixed {
+  b: () => 2;
+  c: 1;
+  a(): 3;
+}
+
 type Point = { x: number; y: number };
 
 export type { Combined, Level, Options, Point };

--- a/test/before/hello.ts
+++ b/test/before/hello.ts
@@ -39,6 +39,12 @@ interface Options {
   Cache: boolean;
 }
 
+interface Mixed {
+  a(): 3;
+  c: 1;
+  b: () => 2;
+}
+
 type Point = { y: number; x: number };
 
 export type { Options, Combined, Level, Point };


### PR DESCRIPTION
Many of our existing repos use this rule