### PR TITLE
Update gradle-dependencies-sorter to 0.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ coursier bootstrap org.scalameta:scalafmt-cli_2.13:3.11.0 \
 # Install static binaries
 wget https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format-1.35.0-all-deps.jar -O google-java-format
 wget https://repo1.maven.org/maven2/com/facebook/ktfmt/0.62/ktfmt-0.62-with-dependencies.jar -O ktfmt
-wget https://repo1.maven.org/maven2/com/squareup/sort-gradle-dependencies-app/0.17.1/sort-gradle-dependencies-app-0.17.1-all.jar -O gradle-dependencies-sorter
+wget https://repo1.maven.org/maven2/com/squareup/sort-gradle-dependencies-app/0.18.0/sort-gradle-dependencies-app-0.18.0-all.jar -O gradle-dependencies-sorter
 wget "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_${TARGETARCH}" -O shfmt
 chmod +x shfmt
 wget "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-${TAPLO_ARCH}.gz" -O taplo.gz

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main hook that runs several code formatters in parallel:
 - [autoflake](https://github.com/myint/autoflake) v1.7.8 for Python <!-- TODO: Remove in favor of Ruff rule F401 once our Python 3 repos that were converted from Python 2 no longer use type hint comments: https://github.com/PyCQA/autoflake/issues/222#issuecomment-1419089254 -->
 - [google-java-format](https://github.com/google/google-java-format) v1.35.0 for Java
 - [ktfmt](https://github.com/facebookincubator/ktfmt) v0.62 for Kotlin
-- [gradle-dependencies-sorter](https://github.com/square/gradle-dependencies-sorter) v0.17.1 for Gradle Kotlin
+- [gradle-dependencies-sorter](https://github.com/square/gradle-dependencies-sorter) v0.18.0 for Gradle Kotlin
 - [gofmt](https://pkg.go.dev/cmd/gofmt) v1.26.2 for Go
 - [scalafmt](https://scalameta.org/scalafmt/) v3.11.0 for Scala
 - [shfmt](https://github.com/mvdan/sh) v3.13.1 for Shell


### PR DESCRIPTION
Includes fix for https://github.com/square/gradle-dependencies-sorter/issues/148