### PR TITLE
Split comma-separated globs into separate Claude paths

### DIFF
--- a/sync_ai_rules/parsers/mdc_parser.py
+++ b/sync_ai_rules/parsers/mdc_parser.py
@@ -50,9 +50,9 @@ class MDCParser(InputParser):
             globs = frontmatter.get("globs", [])
             always_apply = frontmatter.get("alwaysApply", False)
 
-        # Ensure globs is a list
+        # Ensure globs is a list; Cursor stores them as a comma-separated string
         if isinstance(globs, str):
-            globs = [globs] if globs else []
+            globs = [g.strip() for g in globs.split(",") if g.strip()]
         elif not isinstance(globs, list):
             globs = []
 

--- a/test/after/.claude/rules/generated/build-deploy-github-actions.md
+++ b/test/after/.claude/rules/generated/build-deploy-github-actions.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "**/.github/workflows/*.yml"
+  - "**/.github/actions/**/*.yml"
+---
+
+Pin third-party actions to a full commit SHA.

--- a/test/after/.cursor/rules/build-deploy/github-actions.mdc
+++ b/test/after/.cursor/rules/build-deploy/github-actions.mdc
@@ -1,0 +1,7 @@
+---
+description: GitHub Actions workflow guidelines
+globs: "**/.github/workflows/*.yml, **/.github/actions/**/*.yml"
+alwaysApply: false
+---
+
+Pin third-party actions to a full commit SHA.

--- a/test/after/.github/copilot-instructions.md
+++ b/test/after/.github/copilot-instructions.md
@@ -20,6 +20,14 @@ When you decide to apply a rule, you MUST read the entire contents of the actual
 - **File scope**: **/*.swift
 - **Always apply**: false
 
+### Build Deploy
+
+**Github Actions** → `@.cursor/rules/build-deploy/github-actions.mdc`
+
+- **Description**: GitHub Actions workflow guidelines
+- **File scope**: **/.github/workflows/*.yml, **/.github/actions/**/*.yml
+- **Always apply**: false
+
 ### Root
 
 **Rule** → `@.cursor/rules/rule.mdc`

--- a/test/after/AGENTS.md
+++ b/test/after/AGENTS.md
@@ -20,6 +20,14 @@ When you decide to apply a rule, you MUST read the entire contents of the actual
 - **File scope**: **/*.swift
 - **Always apply**: false
 
+### Build Deploy
+
+**Github Actions** → `@.cursor/rules/build-deploy/github-actions.mdc`
+
+- **Description**: GitHub Actions workflow guidelines
+- **File scope**: **/.github/workflows/*.yml, **/.github/actions/**/*.yml
+- **Always apply**: false
+
 ### Root
 
 **Rule** → `@.cursor/rules/rule.mdc`

--- a/test/before/.cursor/rules/build-deploy/github-actions.mdc
+++ b/test/before/.cursor/rules/build-deploy/github-actions.mdc
@@ -1,0 +1,7 @@
+---
+description: GitHub Actions workflow guidelines
+globs: "**/.github/workflows/*.yml, **/.github/actions/**/*.yml"
+alwaysApply: false
+---
+
+Pin third-party actions to a full commit SHA.


### PR DESCRIPTION
## Description

Cursor stores `globs` as a comma-separated string (e.g. `globs: "**/*.yml, **/*.yaml"`). The MDC parser was wrapping this as a single-element list instead of splitting on commas, so the Claude rules generator produced one `paths` entry containing literal commas -- which Claude Code treats as a single glob that never matches.

- Split comma-separated glob strings into individual patterns in `mdc_parser.py`
- Add test fixture with comma-separated globs to cover this case

Context: https://github.com/duolingo/duolingo-ios/pull/68988#discussion_r3375674904

## Verification steps

- [x] `make test` passes with new fixture that uses comma-separated globs
