### PR TITLE
Add new hook for linting/formatting Bazel/Starlark files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ coursier bootstrap org.scalameta:scalafmt-cli_2.13:3.11.0 \
 wget https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format-1.35.0-all-deps.jar -O google-java-format
 wget https://github.com/facebook/ktfmt/releases/download/v0.63/ktfmt-0.63-with-dependencies.jar -O ktfmt
 wget https://repo1.maven.org/maven2/com/squareup/sort-gradle-dependencies-app/0.18.0/sort-gradle-dependencies-app-0.18.0-all.jar -O gradle-dependencies-sorter
+wget "https://github.com/bazelbuild/buildtools/releases/download/v8.5.1/buildifier-linux-${TARGETARCH}" -O buildifier
+chmod +x buildifier
 wget "https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_${TARGETARCH}" -O shfmt
 chmod +x shfmt
 wget "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-${TAPLO_ARCH}.gz" -O taplo.gz

--- a/README.md
+++ b/README.md
@@ -69,4 +69,6 @@ Repo maintainers can declare these hooks in `.pre-commit-config.yaml`:
 
 Directories named `build` and `node_modules` are excluded by default - no need to declare them in the hook's `exclude` key.
 
-Contributors can copy or symlink this repo's `.editorconfig` file to their home directory in order to have their [text editors and IDEs](https://editorconfig.org/) automatically pick up the same linter/formatter settings that this ho
+Contributors can copy or symlink this repo's `.editorconfig` file to their home directory in order to have their [text editors and IDEs](https://editorconfig.org/) automatically pick up the same linter/formatter settings that this hook uses.
+
+_Duolingo is hiring! Apply at https://www.duolingo.com/careers_

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The main hook that runs several code formatters in parallel:
 - [ESLint](https://eslint.org/) v10.2.0 for JS, TypeScript
 - [Ruff](https://docs.astral.sh/ruff/) v0.15.10 for Python
 - [autoflake](https://github.com/myint/autoflake) v1.7.8 for Python <!-- TODO: Remove in favor of Ruff rule F401 once our Python 3 repos that were converted from Python 2 no longer use type hint comments: https://github.com/PyCQA/autoflake/issues/222#issuecomment-1419089254 -->
+- [Buildifier](https://github.com/bazelbuild/buildtools) v8.5.1 for Bazel
 - [google-java-format](https://github.com/google/google-java-format) v1.35.0 for Java
 - [ktfmt](https://github.com/facebookincubator/ktfmt) v0.63 for Kotlin
 - [gradle-dependencies-sorter](https://github.com/square/gradle-dependencies-sorter) v0.18.0 for Gradle Kotlin
@@ -68,6 +69,4 @@ Repo maintainers can declare these hooks in `.pre-commit-config.yaml`:
 
 Directories named `build` and `node_modules` are excluded by default - no need to declare them in the hook's `exclude` key.
 
-Contributors can copy or symlink this repo's `.editorconfig` file to their home directory in order to have their [text editors and IDEs](https://editorconfig.org/) automatically pick up the same linter/formatter settings that this hook uses.
-
-_Duolingo is hiring! Apply at https://www.duolingo.com/careers_
+Contributors can copy or symlink this repo's `.editorconfig` file to their home directory in order to have their [text editors and IDEs](https://editorconfig.org/) automatically pick up the same linter/formatter settings that this ho

--- a/entry.ts
+++ b/entry.ts
@@ -130,7 +130,7 @@ const HOOKS: Record<HookName, Hook> = {
     runAfter: [HookName.Sed],
   },
   [HookName.Buildifier]: {
-    action: sources => run("/buildifier", ...sources),
+    action: sources => run("/buildifier", "--lint=fix", ...sources),
     include:
       /(?:^|\/)(?:BUILD|BUILD\.bazel|WORKSPACE|WORKSPACE\.bazel|MODULE\.bazel)$|\.bzl$/,
     runAfter: [HookName.Sed],

--- a/entry.ts
+++ b/entry.ts
@@ -67,6 +67,7 @@ const transformFile = async (
 
 const enum HookName {
   Autoflake = "autoflake",
+  Buildifier = "Buildifier",
   ClangFormat = "ClangFormat",
   EsLint = "ESLint",
   Gofmt = "gofmt",
@@ -126,6 +127,12 @@ const HOOKS: Record<HookName, Hook> = {
         ...sources,
       ),
     include: /\.py$/,
+    runAfter: [HookName.Sed],
+  },
+  [HookName.Buildifier]: {
+    action: sources => run("/buildifier", ...sources),
+    include:
+      /(?:^|\/)(?:BUILD|BUILD\.bazel|WORKSPACE|WORKSPACE\.bazel|MODULE\.bazel)$|\.bzl$/,
     runAfter: [HookName.Sed],
   },
   [HookName.ClangFormat]: {

--- a/test/after/BUILD.bazel
+++ b/test/after/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
+java_binary(
+    name = "hello",
+    srcs = ["Hello.java"],
+    deps = [":lib"],
+)
+
+java_library(
+    name = "lib",
+    srcs = ["Lib.java"],
+    deps = [
+        "//third_party:guava",
+        "//third_party:jsr305",
+    ],
+)

--- a/test/after/hello.bzl
+++ b/test/after/hello.bzl
@@ -1,0 +1,14 @@
+# "load" lint: java_library and java_test are unused and will be removed
+load("@rules_java//java:defs.bzl", "java_binary")
+
+def create_binary(name, srcs, deps):
+    java_binary(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+def extend_sources(srcs, extra):
+    # "list-append" lint: srcs += [extra] will become srcs.append(extra)
+    srcs.append(extra)
+    return srcs

--- a/test/before/BUILD.bazel
+++ b/test/before/BUILD.bazel
@@ -1,0 +1,12 @@
+load(  "@rules_java//java:defs.bzl",   "java_library","java_binary")
+
+java_binary(name = "hello",
+  deps = [":lib"],
+    srcs = ["Hello.java"],)
+
+java_library(
+    name = "lib",
+  srcs = ["Lib.java"],
+      deps = ["//third_party:guava",
+      "//third_party:jsr305"],
+)

--- a/test/before/hello.bzl
+++ b/test/before/hello.bzl
@@ -1,0 +1,14 @@
+# "load" lint: java_library and java_test are unused and will be removed
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
+def create_binary(name, srcs, deps):
+    java_binary(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+def extend_sources(srcs, extra):
+    # "list-append" lint: srcs += [extra] will become srcs.append(extra)
+    srcs += [extra]
+    return srcs


### PR DESCRIPTION
This PR adds a new pre-commit hook called Buildifier. This hook uses Bazel's [Buildifier](https://github.com/bazelbuild/buildtools/blob/main/buildifier/README.md) tool for formatting Bazel and Starlark files, such as the `MODULE.bazel` file, `BUILD` files, and other arbitrary `*.bzl` files.