### PR TITLE
Support .agents/skills symlinks in subdirectories

### DIFF
--- a/sync_ai_rules/__main__.py
+++ b/sync_ai_rules/__main__.py
@@ -86,9 +86,14 @@ def _ensure_agents_skills_symlinks(project_root: str) -> None:
         if os.path.islink(symlink_path) or os.path.exists(symlink_path):
             continue
 
-        os.makedirs(claude_dir, exist_ok=True)
-        os.symlink(target, symlink_path)
-        print(f"  ✓ Created symlink: {symlink_path} -> .agents/skills")
+        try:
+            os.makedirs(claude_dir, exist_ok=True)
+            os.symlink(target, symlink_path)
+            rel = os.path.relpath(symlink_path, project_root)
+            print(f"  ✓ Created symlink: {rel} -> .agents/skills")
+        except OSError as e:
+            rel = os.path.relpath(dirpath, project_root)
+            logger.warning("Failed to create agents skills symlink at %s: %s", rel, e)
 
 
 def main():

--- a/sync_ai_rules/__main__.py
+++ b/sync_ai_rules/__main__.py
@@ -71,29 +71,41 @@ def _write_gitattributes(directory: str, filenames: List[str]) -> None:
             f.write(f"{name} linguist-generated\n")
 
 
-def _ensure_agents_skills_symlink(project_root: str) -> None:
-    """Create .claude/skills -> .agents/skills so Claude Code discovers Agent Skills."""
-    agents_skills = os.path.join(project_root, ".agents", "skills")
-    if not os.path.isdir(agents_skills):
-        return
+_SKIP_DIRS = frozenset(("build", "node_modules", "DerivedData", "Pods", "vendor"))
 
-    symlink_path = os.path.join(project_root, ".claude", "skills")
-    target = os.path.join("..", ".agents", "skills")
 
-    if os.path.islink(symlink_path):
-        if os.readlink(symlink_path) == target:
-            return
-        os.remove(symlink_path)
-    elif os.path.exists(symlink_path):
-        logger.warning("Skipping symlink: .claude/skills/ already exists as a directory")
-        return
+def _ensure_agents_skills_symlinks(project_root: str) -> None:
+    """Create .claude/skills -> .agents/skills wherever .agents/skills/ exists."""
+    for dirpath, dirnames, _ in os.walk(project_root):
+        dirnames[:] = [
+            d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS
+        ]
 
-    try:
-        os.makedirs(os.path.join(project_root, ".claude"), exist_ok=True)
-        os.symlink(target, symlink_path)
-        print("  ✓ Created symlink: .claude/skills -> .agents/skills")
-    except OSError as e:
-        logger.warning("Failed to create agents skills symlink: %s", e)
+        agents_dir = os.path.join(dirpath, ".agents", "skills")
+        if not os.path.isdir(agents_dir):
+            continue
+
+        claude_dir = os.path.join(dirpath, ".claude")
+        symlink_path = os.path.join(claude_dir, "skills")
+        target = os.path.join("..", ".agents", "skills")
+
+        if os.path.islink(symlink_path):
+            if os.readlink(symlink_path) == target:
+                continue
+            os.remove(symlink_path)
+        elif os.path.exists(symlink_path):
+            rel = os.path.relpath(symlink_path, project_root)
+            logger.warning("Skipping symlink: %s already exists as a directory", rel)
+            continue
+
+        try:
+            os.makedirs(claude_dir, exist_ok=True)
+            os.symlink(target, symlink_path)
+            rel = os.path.relpath(symlink_path, project_root)
+            print(f"  ✓ Created symlink: {rel} -> .agents/skills")
+        except OSError as e:
+            rel = os.path.relpath(dirpath, project_root)
+            logger.warning("Failed to create agents skills symlink at %s: %s", rel, e)
 
 
 def main():
@@ -152,8 +164,8 @@ def main():
     for dir_path, filenames in output_dirs.items():
         _write_gitattributes(os.path.join(project_root, dir_path), sorted(set(filenames)))
 
-    # Create symlink so Claude Code can discover skills from .agents/skills/
-    _ensure_agents_skills_symlink(project_root)
+    # Create symlinks so Claude Code can discover skills from .agents/skills/
+    _ensure_agents_skills_symlinks(project_root)
 
     print("\n✓ Rules synchronization completed!")
 

--- a/sync_ai_rules/__main__.py
+++ b/sync_ai_rules/__main__.py
@@ -71,41 +71,24 @@ def _write_gitattributes(directory: str, filenames: List[str]) -> None:
             f.write(f"{name} linguist-generated\n")
 
 
-_SKIP_DIRS = frozenset(("build", "node_modules", "DerivedData", "Pods", "vendor"))
-
-
 def _ensure_agents_skills_symlinks(project_root: str) -> None:
     """Create .claude/skills -> .agents/skills wherever .agents/skills/ exists."""
-    for dirpath, dirnames, _ in os.walk(project_root):
-        dirnames[:] = [
-            d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS
-        ]
-
+    for dirpath, _, _ in os.walk(project_root):
         agents_dir = os.path.join(dirpath, ".agents", "skills")
         if not os.path.isdir(agents_dir):
             continue
 
         claude_dir = os.path.join(dirpath, ".claude")
         symlink_path = os.path.join(claude_dir, "skills")
+        # Relative target: .claude/skills -> ../.agents/skills
         target = os.path.join("..", ".agents", "skills")
 
-        if os.path.islink(symlink_path):
-            if os.readlink(symlink_path) == target:
-                continue
-            os.remove(symlink_path)
-        elif os.path.exists(symlink_path):
-            rel = os.path.relpath(symlink_path, project_root)
-            logger.warning("Skipping symlink: %s already exists as a directory", rel)
+        if os.path.islink(symlink_path) or os.path.exists(symlink_path):
             continue
 
-        try:
-            os.makedirs(claude_dir, exist_ok=True)
-            os.symlink(target, symlink_path)
-            rel = os.path.relpath(symlink_path, project_root)
-            print(f"  ✓ Created symlink: {rel} -> .agents/skills")
-        except OSError as e:
-            rel = os.path.relpath(dirpath, project_root)
-            logger.warning("Failed to create agents skills symlink at %s: %s", rel, e)
+        os.makedirs(claude_dir, exist_ok=True)
+        os.symlink(target, symlink_path)
+        print(f"  ✓ Created symlink: {symlink_path} -> .agents/skills")
 
 
 def main():

--- a/test/after/subdir/.agents/skills/my-skill/SKILL.md
+++ b/test/after/subdir/.agents/skills/my-skill/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: my-skill
+description: A test skill
+---
+
+Test skill content.

--- a/test/after/subdir/.claude/skills
+++ b/test/after/subdir/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/test/before/subdir/.agents/skills/my-skill/SKILL.md
+++ b/test/before/subdir/.agents/skills/my-skill/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: my-skill
+description: A test skill
+---
+
+Test skill content.


### PR DESCRIPTION
## Description
- Walk the project tree to find all `.agents/skills/` directories (not just the repo root) and create a sibling `.claude/skills` symlink for each
- Enables teams to place skills in feature subdirectories (e.g. `VideoCall/.agents/skills/`) while keeping Claude Code discovery working via the symlink

## Verification steps
- [X] Run `python3 -m sync_ai_rules` in a repo with `.agents/skills/` in a subdirectory and verify `.claude/skills` symlink is created next to it
- [X] Unit tests