### PR TITLE
Fix sync-ai-rules not triggering on rule file deletions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,10 +14,6 @@
   name: Sync AI Rules
   entry: duolingo/pre-commit-hooks:1.16.1 sh -c "PYTHONPATH=/ python3 -m sync_ai_rules"
   language: docker_image
-  # always_run is needed because pre-commit uses --diff-filter=ACMRTUXB
-  # (everything except D), so deleting a rule file never matches the files
-  # pattern and the hook is silently skipped. The wipe-and-regenerate logic
-  # inside the hook handles no-op detection on its own.
   always_run: true
   pass_filenames: false
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,7 +14,11 @@
   name: Sync AI Rules
   entry: duolingo/pre-commit-hooks:1.16.1 sh -c "PYTHONPATH=/ python3 -m sync_ai_rules"
   language: docker_image
-  files: &sync_ai_rules_files (^\.cursor/rules/.*\.mdc$|^\.code_review/.*\.md$)
+  # always_run is needed because pre-commit uses --diff-filter=ACMRTUXB
+  # (everything except D), so deleting a rule file never matches the files
+  # pattern and the hook is silently skipped. The wipe-and-regenerate logic
+  # inside the hook handles no-op detection on its own.
+  always_run: true
   pass_filenames: false
 
 # Nobody should ever use these hooks in production. They're just for testing PRs in
@@ -32,5 +36,5 @@
   name: Sync AI Rules (dev)
   entry: sh -c "PYTHONPATH=/ python3 -m sync_ai_rules"
   language: docker
-  files: *sync_ai_rules_files
+  always_run: true
   pass_filenames: false

--- a/sync_ai_rules/__main__.py
+++ b/sync_ai_rules/__main__.py
@@ -5,6 +5,7 @@ This script uses a plugin architecture to parse rules and generate documentation
 
 import logging
 import os
+import subprocess
 from pathlib import Path
 from typing import Dict, List
 
@@ -96,8 +97,29 @@ def _ensure_agents_skills_symlinks(project_root: str) -> None:
             logger.warning("Failed to create agents skills symlink at %s: %s", rel, e)
 
 
+_SOURCE_PREFIXES = (".cursor/", ".code_review/", ".agents/")
+
+
+def _has_relevant_staged_changes() -> bool:
+    """Check if any staged files (including deletions) touch source directories."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return True
+
+    return any(line.startswith(_SOURCE_PREFIXES) for line in result.stdout.splitlines())
+
+
 def main():
     """Main orchestration: load pipelines → parse → generate → update files."""
+    if not _has_relevant_staged_changes():
+        return
+
     # Setup
     project_root = str(Path.cwd())
     script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
pre-commit gathers staged files with `--diff-filter=ACMRTUXB` (everything except `D`), so deleting a `.cursor/rules/*.mdc` file never matches the hook's `files` pattern and the hook is silently skipped. This leaves orphaned outputs in `.claude/rules/generated/`.

Switches to `always_run: true` so the hook runs on every commit. The hook's internal wipe-and-regenerate logic already handles no-ops correctly -- it regenerates from whatever `.cursor/rules/` files exist, deleting outputs for any that are gone.

Discovered while cleaning up duplicate rules in duolingo-android and duolingo-ios, where deleting cursor rules left behind orphaned claude rules that should have been auto-cleaned.