### PR TITLE
Rename Review guidelines heading to Code Review Rules

### DIFF
--- a/sync_ai_rules/generators/code_review_guidelines_generator.py
+++ b/sync_ai_rules/generators/code_review_guidelines_generator.py
@@ -26,7 +26,7 @@ class CodeReviewGuidelinesGenerator(BaseGenerator):
             "<code-review-guidelines>",
             "<!-- DO NOT EDIT THIS SECTION - Auto-generated from .code_review/ -->",
             "",
-            "## Review guidelines",
+            "## Code Review Rules",
             "",
         ]
 

--- a/test/after/AGENTS.md
+++ b/test/after/AGENTS.md
@@ -49,7 +49,7 @@ When you decide to apply a rule, you MUST read the entire contents of the actual
 <code-review-guidelines>
 <!-- DO NOT EDIT THIS SECTION - Auto-generated from .code_review/ -->
 
-## Review guidelines
+## Code Review Rules
 
 ### Architecture
 


### PR DESCRIPTION
## Description
- Rename the generated section heading from `## Review guidelines` to `## Code Review Rules` in the code review guidelines generator to align with Codex's guidelines

## Verification steps
- Regenerate AGENTS.md via sync_ai_rules and confirm the section heading reads `## Code Review Rules`.